### PR TITLE
https redirect: use location.replace(...) instead of location.href = ...

### DIFF
--- a/src/YouTubeCenter.user.js
+++ b/src/YouTubeCenter.user.js
@@ -22582,7 +22582,7 @@
       ytcenter.pageReadinessListener.addEventListener("headerInitialized", function(page){
         if (ytcenter.settings.useSecureProtocol && page !== "comments") {
           if (loc.href.indexOf("http://") === 0) {
-            loc.href = loc.href.replace(/^http/, "https");
+            loc.replace(loc.href.replace(/^http/, "https"));
             return;
           }
         }


### PR DESCRIPTION
Currently, when redirecting from http to https, there will be two
entries added in the browser history.
Pressing "back" will go back to "http", and YouTubeCenter, in return,
will redirect to "https" again, effectively causing an infinite loop.

Use location.replace() instead, because that does not create another
history entry in the browser and the back button works as expected.
