### PR TITLE
Check that localStorage is accessible before accessing it

### DIFF
--- a/src/YouTubeCenter.user.js
+++ b/src/YouTubeCenter.user.js
@@ -26017,7 +26017,7 @@
     if (chrome && chrome.storage && chrome.storage.local) {
       var storage = chrome.storage.local;
       var value = null;
-      if ((value = localStorage.getItem(key) || null) !== null) {
+      if (support.localStorage && (value = localStorage.getItem(key) || null) !== null) {
         console.log("[Chrome] Moving settings from old method to new method for " + key);
         var details = {};
         details[key] = value;
@@ -26048,7 +26048,7 @@
     if (chrome && chrome.storage && chrome.storage.local) {
       var storage = chrome.storage.local;
       var value = null;
-      if ((value = localStorage.getItem(key) || null) !== null) {
+      if (support.localStorage && (value = localStorage.getItem(key) || null) !== null) {
         console.log("[Chrome] Moving settings from old method to new method for " + key);
         var details = {};
         details[key] = value;


### PR DESCRIPTION
This should fix YePpHa/YouTubeCenter/issues/1604.

Basic problem is that window.localStorage is not accessible when the "block third-party cookies and site data" option is enabled in Chrome. When the extension JS tries to access it, the following error is thrown:

Uncaught SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.

This pull request introduces a simple check before accessing localStorage, to ensure it's actually accessible.


