### PR TITLE
Specify @noframes for user script.

### DIFF
--- a/src/.meta/YouTubeCenter.meta.js
+++ b/src/.meta/YouTubeCenter.meta.js
@@ -45,4 +45,5 @@
 // @supportURL      https://github.com/YePpHa/YouTubeCenter/issues
 // @run-at          document-start
 // @priority        9001
+// @noframes
 // ==/UserScript==


### PR DESCRIPTION
It's very common to embed YouTube videos as iframes now; today the user script runs on every one of them, for no benefit.  Both Greasemonkey and Tampermonkey support the @noframes directive, to skip this inefficient behavior.
